### PR TITLE
Fix setuptools warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/virtual_maize_field
+script_dir=$base/lib/virtual_maize_field
 [install]
-install-scripts=$base/lib/virtual_maize_field 
+install_scripts=$base/lib/virtual_maize_field 


### PR DESCRIPTION
To ignore warnings like these:

```
/usr/local/lib/python3.8/dist-packages/setuptools/dist.py:714: UserWarning: Usage of dash-separated 'install-scripts' will not be supported in future versions. Please use the underscore name 'install_scripts' instead warnings.warn(
```